### PR TITLE
Update functions.php

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -28,7 +28,7 @@ function alterAdmin($args) {
     if(!$Wcms->loggedIn) return $args;
 
     $doc = new DOMDocument();
-    @$doc->loadHTML($args[0]);
+    @$doc->loadHTML('<meta http-equiv="Content-Type" content="text/html; charset=utf-8">' . $args[0]);
 
     /* Input element for header height */
 
@@ -153,7 +153,7 @@ function alterAdmin($args) {
 
     $doc->getElementById("currentPage")->insertBefore($form_group, $doc->getElementById("currentPage")->lastChild->previousSibling->previousSibling);
 
-    $args[0] = preg_replace('~<(?:!DOCTYPE|/?(?:html|body))[^>]*>\s*~i', '', $doc->saveHTML());
+    $args[0] = urldecode( preg_replace('~<(?:!DOCTYPE|/?(?:html|body))[^>]*>\s*~i', '', $doc->saveHTML() ));
     return $args;
 }
 $Wcms->addListener('settings', 'alterAdmin');


### PR DESCRIPTION
This change fixes "about:blank#blocked" on admin save changes or logout. Also change fixes Content-Type in admin page in input fields "current page" (page title, page keywords, page description), and menu (website title). In original in admin menu diacritic marks like ĄĘŚĆ are displayed Ä„Ä˜ÅšÄ† . 

![image](https://github.com/robiso/parallax/assets/162060947/e529f576-4114-468e-802d-6b76637f119d)
